### PR TITLE
Do not emit duplicated files when not watching

### DIFF
--- a/index.js
+++ b/index.js
@@ -250,7 +250,9 @@ module.exports = class CompileTypescriptPlugin {
 
             this.fileList.push(newFile);
             this.initFileWatcher([newFile]);
-            this.emitFiles([newFile]);
+            if (this.pluginOptions.watch) {
+                this.emitFiles([newFile]);
+            }        
         }
     }
 

--- a/index.js
+++ b/index.js
@@ -95,6 +95,7 @@ module.exports = class CompileTypescriptPlugin {
             if (!this.pluginOptions.watch) {
                 this.incrementFilesVersion(this.fileList);
                 this.emitFiles(this.fileList);
+                this.srcWatcher.close();
             }
             callback();
         });


### PR DESCRIPTION
Problems:
- If set `watch: false` for the plugin all files emitted twice.
- Also, the webpack will _never_ exit as `srcWatcher` keep watching files.

Changes:
When we are not watching, close `srcWatcher` after files emitted.
When we the change coming from `srcWatcher` emit file _only_ if we are watching for changes.


The second problem doesn't occur if you are using webpack through grunt.